### PR TITLE
Update to nom 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable `password-rules-parser` changes, tracked in the [keep a changelog](https
 
 ## [Unreleased]
 
+### Changed
+
+* Updated `nom` from v5 to v6
+
 ## [1.0.0] - 2020-11-03
 
 Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 itertools = "0.9"
-nom = "5"
+nom = "6"
 pretty-lint = "0.1"
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display, Formatter, Write};
 use std::{convert::TryInto, error::Error};
 
 use itertools::{Itertools, Position::*};
-use nom::error::{ErrorKind, ParseError};
+use nom::error::{ErrorKind, FromExternalError, ParseError};
 use pretty_lint::{Position, PrettyLint, Span};
 
 /// Extension trait for nom::error::ParseError that allows for collecting the
@@ -175,6 +175,12 @@ impl<'a> WithTagError<&'a str> for PasswordRulesErrorContext<'a> {
                 expected: Expected::Tag(tag),
             }],
         }
+    }
+}
+
+impl<'a> FromExternalError<&'a str, std::num::ParseIntError> for PasswordRulesErrorContext<'a> {
+    fn from_external_error(input: &'a str, kind: ErrorKind, _: std::num::ParseIntError) -> Self {
+        Self::from_error_kind(input, kind)
     }
 }
 


### PR DESCRIPTION
Updates the crate to [nom 6](https://github.com/Geal/nom/blob/master/CHANGELOG.md#600---2020-10-31).

This mostly involved making a lot of `Fn`s `FnMut` and adding a few additional error bounds to some function args.

I've implemented `FromExternalError` for `PasswordRulesErrorContext` in a way that discards the external error information; We could include the `ParseIntError` in the `Expected::Number` variant, but then we'd have to remove the `Copy` derive from `ParseIntError`. Opinions welcome.